### PR TITLE
Can now specify multiple anchors per latent factor.

### DIFF
--- a/corex_topic.py
+++ b/corex_topic.py
@@ -170,11 +170,20 @@ class Corex(object):
             if self.n_hidden > 1 and nloop > 0:  # Structure learning step
                 self.alpha = self.calculate_alpha(X, p_y_given_x, self.theta, self.log_p_y, self.tcs)
             if anchors is not None:
-                for a in set(anchors):
-                    self.alpha[:, a] = 0
-                for ia, a in enumerate(anchors):
-                    self.alpha[ia, a] = anchor_strength
-
+##### BEGIN DCK #####
+                for A in anchors:
+                    try:
+                        for a in A:
+                            self.alpha[:, a] = 0
+                    except:
+                        self.alpha[:, A] = 0
+                for ia, A in enumerate(anchors):
+                    try:
+                        for a in A:
+                            self.alpha[ia, a] = anchor_strength
+                    except:
+                        self.alpha[ia, A] = anchor_strength
+##### END DCK #####
             p_y_given_x, log_z = self.calculate_latent(X, self.theta)
 
             self.update_tc(log_z)  # Calculate TC and record history to check convergence


### PR DESCRIPTION
Can now specify multiple anchors per latent factor. Anchors argument is a list and can mix integers and lists of integers. TODO: modify corex_vis code.
