### PR TITLE
Update for functionality with word and doc labels. Update to example notebook

### DIFF
--- a/examples/corex-topic-example.ipynb
+++ b/examples/corex-topic-example.ipynb
@@ -1,1000 +1,986 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:557939242e90e1cb62b5c2ecc8ebfa9c081fb86c98191915101f6b1b20210a53"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Anchored CorEx: Topic Modeling with Minimal Domain Knowledge"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "**Author:** [Ryan J. Gallagher](http://ryanjgallagher.github.io/), 07/07/2017"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This notebook walks through how to use the CorEx topic model code. This includes fitting CorEx to your data, examining the topic model output, outputting results, building a hierarchical topic model, and anchoring words to topics. It is assumed that corex_topic.py and vis_topic.py are in your working directory, and that you have numpy, scipy, and scikit-learn installed. \n",
-      "\n",
-      "Details of the CorEx topic model and evaluations against unsupervised and semi-supervised variants of LDA can be found in our paper:\n",
-      "\n",
-      "[*Anchored Correlation Explanation: Topic Modeling with Minimal Domain Knowledge*](https://arxiv.org/abs/1611.10277), Gallagher et al., preprint 2017."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy as np\n",
-      "import vis_topic as vt\n",
-      "import corex_topic as ct\n",
-      "import scipy.sparse as ss\n",
-      "import matplotlib.pyplot as plt\n",
-      "\n",
-      "from sklearn.datasets import fetch_20newsgroups\n",
-      "from sklearn.feature_extraction.text import CountVectorizer"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Loading the 20 Newsgroups Dataset"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We need to first load data to run the CorEx topic model. We'll use the 20 Newsgroups dataset, which scikit-learn provides functionality to access."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Get 20 newsgroups data\n",
-      "newsgroups = fetch_20newsgroups(subset='train', remove=('headers', 'footers', 'quotes'))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The topic model assumes input is in the form of a doc-word matrix, where rows are documents and columns are binary counts. We'll vectorize the newsgroups data, take the top 20,000 words, and convert it to a sparse matrix to save on memory usage. Note, we use binary count vectors as input to the CorEx topic model."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Transform 20 newsgroup data into a sparse matrix\n",
-      "vectorizer = CountVectorizer(stop_words='english', max_features = 20000, binary = True)\n",
-      "doc_word = vectorizer.fit_transform(newsgroups.data)\n",
-      "doc_word = ss.csr_matrix(doc_word)\n",
-      "\n",
-      "doc_word.shape # n_docs x m_words"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "(11314, 20000)"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Our doc-word matrix is 11,314 documents by 20,000 words. Let's get the words that label the columns. We'll need these for outputting readable topics and later for anchoring."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Get words that label the columns (needed to extract readable topics and make anchoring easier)\n",
-      "words = list(np.asarray(vectorizer.get_feature_names()))"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We'll do a final step of preprocessing where we remove all integers from our set of words. This brings is down to 19,038 words."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "not_digit_inds = [ind for ind,word in enumerate(words) if not word.isdigit()]\n",
-      "doc_word = doc_word[:,not_digit_inds]\n",
-      "words    = [word for ind,word in enumerate(words) if not word.isdigit()]\n",
-      "\n",
-      "doc_word.shape # n_docs x m_words"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 6,
-       "text": [
-        "(11314, 19038)"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "CorEx Topic Model"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The main paramters of the CorEx topic model are:\n",
-      "+ **n_hidden**: number of topics (\"hidden\" as in \"hidden latent topics\")\n",
-      "+ **words**: words that label the columns of the doc-word matrix (optional)\n",
-      "+ **max_iter**: number of iterations to run through the update equations\n",
-      "+ **verbose**:  if *verbose=1*, then CorEx will print the topic TCs with each iteration\n",
-      "+ **seed**:     random number seed to use for model initialization\n",
-      "\n",
-      "We'll train a topic model with 50 topics. (This will take a few minutes.)"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Train the CorEx topic model with 50 topics\n",
-      "topic_model = ct.Corex(n_hidden=50, words=words, max_iter=200, verbose=False, seed=None)\n",
-      "topic_model.fit(doc_word, words=words);"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "CorEx Output"
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Topics"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The CorEx topic model provides functionality for easily accessing the topics. Let's take a look one of the topics."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Print a single topic from CorEx topic model\n",
-      "topic_model.get_topics(topic=2, n_words=10)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 10,
-       "text": [
-        "[(u'team', 0.076923542033639589),\n",
-        " (u'game', 0.070597907332178161),\n",
-        " (u'players', 0.049635998742710227),\n",
-        " (u'season', 0.048588199138651741),\n",
-        " (u'games', 0.045133991049044066),\n",
-        " (u'league', 0.042554543381838159),\n",
-        " (u'hockey', 0.042069081701358556),\n",
-        " (u'play', 0.04065046908318385),\n",
-        " (u'teams', 0.038205134081690545),\n",
-        " (u'nhl', 0.030570297127264282)]"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The topic words are those with the highest *mutual information* with the topic, rather than those with highest probability within the topic as in LDA. The mutual information with the topic is the number reported in each tuple. If the column labels have not been specified through **words**, then the code will return the column indices for the top words in each topic.\n",
-      "\n",
-      "We can also retrieve all of the topics at once if we would like."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Print all topics from the CorEx topic model\n",
-      "topics = topic_model.get_topics()\n",
-      "for n,topic in enumerate(topics):\n",
-      "    topic_words,_ = zip(*topic)\n",
-      "    print '{}: '.format(n) + ','.join(topic_words)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "0: d9,ei,1t,mw,mq,wm,m9,m3,m_,wt\n",
-        "1: windows,card,dos,software,pc,files,disk,drive,file,ram\n",
-        "2: team,game,players,season,games,league,hockey,play,teams,nhl\n",
-        "3: information,including,number,press,published,office,sent,received,include,major\n",
-        "4: israel,armenians,armenian,israeli,argic,geb,turkish,chastity,n3jxp,shameful\n",
-        "5: way,point,example,real,does,means,far,non,based,reason\n",
-        "6: people,law,rights,state,laws,religion,children,crime,religious,society\n",
-        "7: god,jesus,christian,christ,christians,bible,church,faith,christianity,jews\n",
-        "8: archive,anonymous,modified,pub,various,distributed,distribution,faq,site,obtain\n",
-        "9: key,encryption,clipper,keys,public,secure,nsa,security,escrow,encrypted\n",
-        "10: hit,smith,dave,red,staff,runs,hitter,ball,base,hr\n",
-        "11: government,gun,guns,weapons,police,military,federal,citizens,protect,political\n",
-        "12: use,using,work,used,problem,program,set,running,help,problems\n",
-        "13: april,washington,york,los,angeles,st,conference,final,ny,pp\n",
-        "14: car,bike,cars,engine,miles,road,ride,riding,bikes,ground\n",
-        "15: window,server,unix,application,motif,x11r5,mit,sun,display,widget\n",
-        "16: edu,university,internet,apr,date,send,com,mail,address,cs\n",
-        "17: war,killed,troops,kill,anti,soviet,killing,attack,million,innocent\n",
-        "18: national,world,american,international,issue,policy,countries,nation,administration,continue\n",
-        "19: human,history,word,existence,book,exist,follow,century,exists,accept\n",
-        "20: code,following,note,function,written,functions,create,text,write,created\n",
-        "21: general,research,subject,science,form,issues,scientific,related,individual,knowledge\n",
-        "22: end,order,questions,later,present,future,provide,short,single,asked\n",
-        "23: fact,said,did,life,man,saying,understand,women,taken,agree\n",
-        "24: year,years,day,days,night,started,city,san,didn,great\n",
-        "25: nasa,launch,orbit,shuttle,mission,satellite,gov,jpl,orbital,solar\n",
-        "26: say,right,come,let,doesn,wrong,course,tell,actually,makes\n",
-        "27: space,high,large,low,small,power,cost,moon,light,water\n",
-        "28: believe,person,true,mean,mind,words,claim,country,live,certainly\n",
-        "29: volume,source,document,electronic,operation,pages,remote,programming,features,selected\n",
-        "30: united,states,president,congress,term,modern,authors,earth,council,books\n",
-        "31: given,important,place,involved,certain,situation,attempt,position,conclusion,clearly\n",
-        "32: sale,new,price,condition,offer,shipping,sell,includes,interested,asking\n",
-        "33: second,center,left,period,defense,early,young,west,2nd,late\n",
-        "34: data,chip,speed,bit,faster,memory,digital,performance,fast,output\n",
-        "35: just,think,good,really,probably,little,isn,maybe,big,feel\n",
-        "36: long,likely,rest,outside,carry,return,numbers,area,hold,remain\n",
-        "37: group,groups,consider,common,article,sources,posting,cases,established,purposes\n",
-        "38: medical,disease,doctor,patients,treatment,medicine,health,hospital,doctors,pain\n",
-        "39: don,like,time,know,make,things,want,going,thing,look\n",
-        "40: evidence,sense,action,body,arguments,described,studies,definition,education,understanding\n",
-        "41: better,ve,ll,best,money,got,lot,unless,buy,pretty\n",
-        "42: away,finally,open,head,usually,hours,spent,quickly,stay,returned\n",
-        "43: went,start,getting,turn,turned,goes,safe,range,couple,results\n",
-        "44: having,read,different,trying,try,post,instead,response,hope,exactly\n",
-        "45: reference,changes,variety,versions,save,guide,global,style,commands,edge\n",
-        "46: cause,msg,foods,allergic,caused,eating,normal,reaction,chinese,flavor\n",
-        "47: today,held,local,kept,brought,chief,potential,financial,meetings,technologies\n",
-        "48: john,paul,jim,____,___,__,jmd,bobby,_____,tom\n",
-        "49: apply,clinton,animals,natural,allowed,business,responsible,practice,humans,stand\n"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note, the first topic looks a bit odd, but these characters were used frequently to encode images. The CorEx topic model picks up on these encodings as a topic since they were not cleaned from the data.\n",
-      "\n",
-      "We can also get the column indices instead of the column labels if necessary"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "topic_model.get_topics(topic=5, n_words=10, print_words=False)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 12,
-       "text": [
-        "[(18439, 0.062895169916894436),\n",
-        " (13031, 0.057064788895767611),\n",
-        " (6156, 0.042499843896452484),\n",
-        " (14061, 0.040650963987542428),\n",
-        " (5239, 0.040585565048779311),\n",
-        " (10704, 0.038090337085622462),\n",
-        " (6472, 0.035621105523664411),\n",
-        " (11705, 0.034192155984281943),\n",
-        " (1798, 0.033973229268166712),\n",
-        " (14079, 0.033920394063488103)]"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If we need to directly access the topic assignments for each word, they can be accessed through **cluster**."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print topic_model.clusters\n",
-      "print topic_model.clusters.shape # m_words"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[ 0  1 16 ..., 14  0  0]\n",
-        "(19038L,)\n"
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Document Labels"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "CorEx is a *discriminative* model, whereas LDA is a *generative* model. This means that while LDA outputs a probability distribution over each document, CorEx instead estimates the probability a document belongs to a topic given that document's words. As a result, the probabilities across topics for a given document do not have to add up to 1. The estimated probabilities of topics for each document can be accessed through **p_y_given_x**."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print topic_model.p_y_given_x.shape # n_docs x k_topics"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "(11314L, 50L)\n"
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can also use a softmax to make a binary determination of which documents belong to each topic. These softmax labels can be accessed through **labels**."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print topic_model.labels.shape # n_docs x k_topics"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "(11314L, 50L)\n"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Since CorEx does not prescribe a probability distribution of topics over each document, this means that a document could possibly belong to no topics (all 0's across topics in **labels**) or all topics (all 1's across topics in **labels**)."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Total Correlation and Model Selection"
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Overall TC"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Total correlation is the measure which CorEx tries maximize when constructing the topic model. It can be accessed through **tc** and is reported in nats."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "topic_model.tc"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 16,
-       "text": [
-        "46.261927990744361"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "**Model selection:** CorEx starts its algorithm with a random initialization, and so different runs can result in different topic models. One way of finding a better topic model is to restart the CorEx algorithm several times and take the run that has the highest TC value (i.e. the run that produces topcis that are most informative about the documents)."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Topic TC"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The overall total correlation is the sum of the total correlation per each topic. These can be accessed through **tcs**. Note the topic TCs are always sorted from high to low for unsupervised CorEx (this is not the case if anchoring is done)."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "topic_model.tcs.shape # k_topics"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 17,
-       "text": [
-        "(50L,)"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print np.sum(topic_model.tcs)\n",
-      "print topic_model.tc"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "46.2619279907\n",
-        "46.2619279907\n"
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "**Selecting number of topics:** one way to choose topics is to observe the distribution of TCs for each topic to see how much each additional topic contributes to the overall TC. We should keep adding topics until additional topics do not significantly add to the overall TC. This is similar to choosing a cutoff eigenvalue when doing topic modeling via LSA."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "plt.bar(range(topic_model.tcs.shape[0]), topic_model.tcs, color = '#f29fe4', width = 0.6)\n",
-      "plt.xlabel('Topic', fontsize = 16)\n",
-      "plt.ylabel('Total Correlation (nats)', fontsize = 16)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 19,
-       "text": [
-        "<matplotlib.text.Text at 0x11724080>"
-       ]
-      },
-      {
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAYEAAAEUCAYAAADN8orUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAGblJREFUeJzt3XmUZWV57/HvD5AW0BZBBhUBFRUlMYITioYWVMBZl4lD\n0Mgy4WpQMZooooaLRsQBuZjEMYhG23loJFHBgOUQl4ICgjSaXBEUbVoRBblIMz33j72bLoqu6n26\nzz6nqs73s9ZZdfZ+99n7qb26z1PvfqdUFZKkybTZuAOQJI2PSUCSJphJQJImmElAkiaYSUCSJphJ\nQJIm2FiSQJK7JPlMkouTXJTkkeOIQ5Im3RZjuu5JwJeq6s+SbAFsPaY4JGmiZdSDxZIsBc6rqvuO\n9MKSpNsZx+OgewNXJjklyblJPpBkqzHEIUkTbxxJYAtgH+Bfqmof4DrgqDHEIUkTbxxtApcDP6+q\n77XbnwVeO/OgJE5qJEkDqqoMcvzIawJVtRr4eZL7t7sOBFbOcqyvKo455pixxzAfXt4H74X3Yu7X\nxhhX76BXAMuT3AG4BDhsTHFI0kQbSxKoqh8ADx/HtSVJ6zhieAFYtmzZuEOYF7wP63gv1vFebJqR\njxPoKknN19gkaT5KQs33hmFJ0vxhEpCkCWYSkKQJZhKQpAlmEpCkCWYSkKQJZhKQpAlmEpCkCWYS\nkKQJZhKQpAlmEpCkCWYSkKQJNq+TQJJbX7vfa7dxhyNJi864FpXp5JpTLr/1/dLDdhljJJK0OHVK\nAkmWAPvRLASzc7v7CuB7wH9V1fX9hCdJ6tOcSSDJHsDfAocCd253X9P+XNr+vDbJcuBdVfU/vUQp\nSerFrG0CSU4ELgIeBvxD+3PLqtq2qrYFlrT73gjsDfwwybv6D1mSNCxz1QTuDzyqqs5dX2FV3Qic\n275OSrI38ObhhyhJ6susSaCqnjzIiarqPOApmxyRJGlk5nUXUUlSvzolgSRPSnLotO17Jvlakl8n\n+ViSrfsLUZLUl641gWOA6R31TwT2BD4NHELTcCxJWmC6JoE9gB8AJLkjzbP/V1XVEcDrgGf3E54k\nqU9dk8BWwHXt+0cBWwJfabcvBu4x5LgkSSPQNQlcBuzbvn8qcG5V/bbd3gH4/bADkyT1r+vcQScD\nb0nyVOCRwCumle1LUxuQJC0wnZJAVb0zyW9pvvD/DfjgtOIdgI8OctEklwJXA7cAN1bVIwb5vCRp\nOLpOILcj8OGqOnk9xX8FbD/gdW8Blk17pCRJGoOubQKrgIfOUvaQtnwQGeDakqSedP0izhxlW9D8\nZT+IAr6a5Jwkfz3gZyVJQzLr46Akd2LddNEAd0sysyvoVsDzgdUDXne/qlqVZAeaZHBxVX1rwHNI\nkjbRXG0Cr2bdSOACTpvluABvGeSiVbWq/fnrJF8AHgHcLgkct+KEQU4rSRNlamqKqampTTpHqmr9\nBclDadYLCPAe4O3AT2cctgZYWVVnd75gM8/QZlV1bZJtgDOAY6vqjBnH1czlJWeLVZLUrMteVXM9\nvr+duaaS/j7w/fbEBXyuqq7ctBAB2An4QnvOLYDlMxOAJGk0uo4TeP+wLlhVP6XpUSRJGrOuI4ZJ\ncn/gMOABwB1nFNegi9BIksav62CxhwLfpOkFtCvwY2A7YEfgl8DP+gpQktSfruMEjgf+A7gfTUPx\noVW1M82U0psBr+0nPElSn7omgT8BPsy6QWGbA1TVl4DjaHoOSZIWmK5JYAlwbVXdAlxF08NnrZXA\ng4cdmCSpf12TwCWsW17yIuBF08oOBX41xJgkSSPStXfQl4HHA8uBtwKnJbkKuIlmBtG/6yc8SVKf\nuo4TOHra+68keSzNusJbA1+pqi/2FJ8kqUedxwlMV1XfAb4z5FgkSSPmnP6SNMG6DhbbgmZW0efR\nDBZb34jhbYYcmySpZ10fBx0PvAo4EziLZvZQSdIC1zUJPJdmuudj+wxGkjRaXdsEltLMHSRJWkS6\nJoEvA4/uMxBJ0uh1fRz0NmB5khuAL9FMHXEbVfXLYQYmSepf1yTwvfbn8TQjhtdn800PR5I0Sl2T\nwN/QLDYvSVpEuk4b8b6+A5EkjZ4jhiVpgs2aBJK8Ncm2XU+U5K5JZmsvkCTNQ3PVBB4OXJrkfUke\nm2TJzAOS3DHJ45J8ALgUeFhPcUqSejBrm0BVPT7JU4HXAF8HbkhyCfCb9pDtgfu25/gu8MKqOrXn\neCVJQzRnw3BVnUazgMyewCE0f+mvXVryPOCDwBlVdVGvUUqSetG1d9CPgB/1HIskacTsHSRJE8wk\nIEkTzCQgSRPMJCBJE2xsSSDJZknOTfLFccUgSZNunDWBI4GVY7y+JE28rrOIApDkIax/oXmq6tMD\nnGcX4EnAW2jWLpYkjUGnJJDk/sDngQcCWc8hBXROAsCJwN8DdxngM5KkIetaE3gPzTrDLwQuBNZs\n7AWTPBlYXVXnJ1nG+pMKAMetOGFjLyNJi97U1BRTU1ObdI5UbXitmCTXAC+uqs9s0tWacx0HHArc\nBGwF3Bn4fFW9cMZxdc0pl9+6vfSwXegSqyRNqiRU1ax/WK9P14bhq4DrBg/p9qrq6KrataruAzwX\nOGtmApAkjUbXJPBu4CVJBsowkqT5rWubwFbAXsAFSU6nqRlMV1U18IIyVfV1mmmqJUlj0DUJvHna\n+73WU16Aq4pJ0gIzSE1AkrTIdF1PYKO7hEqS5q9BRww/Htgf2I6mXWCqqs7sIzBJUv+6jhjeGjgV\nOIBmcNfVNIPHjk5yJvD0qvpDb1FKknrRtYvoccB+wOHA1lV1V2CbdvvRNHMASZIWmK5J4NnAG6rq\n5Kq6HqCqrq+qk4FjgD/vK0BJUn+6JoEdgAtmKfsBcLfhhCNJGqWuSeAy4OBZyp7YlkuSFpiuvYP+\nFTg+yVbAcmAVsDPN3D9HAEf1E54kqU9dk8A7aL70Xwa8ZNr+m4GTquqdww5MktS/roPFCnhVkrfR\n9AZaO07g21W1usf4JEk9GmiwWPuF/4WeYpEkjdisSSDJI4AfVtV17fs5VdXZQ41MktS7uWoC3wH2\nBc5u38+2rFfass2HG5okqW9zJYFDgIvb909i9iQgSVqgZk0CVXX6tPdfGU04kqRR6jRYLMnKJH88\nS9mDkqwcbliSpFHoOmJ4T2ZfWGZr4AHDCUeSNEpdkwDM3ibwYJqppSVJC8xcXURfDry83Szgs0lm\nrjC2FXAP4LP9hCdJ6tNcvYN+CXy/fb8H8GPgNzOOWQOsBN47/NAkSX2bq3fQ54DPASQBeH1VXTKi\nuCRJI9B17qDn9R2IJGn0Os8dlGRz4PE0PYHuOKO4quodwwxMktS/rgvN7wR8Hbg/TSNx2qLpPYZM\nApK0wHTtIvp24P/RJIEAfwo8CDgB+AmOE5CkBalrElhG85f+T9vtP1TVj6rqNcAK4G09xCZJ6tkg\nC83/oqpupqkRbDut7HTgwK4XTLIkyXeTnJfkoiTHdQ9XkjRMXZPAL2gSATS1gQOmle1DM16gk6pa\nAzyuqvamGW18QJL9un5ekjQ8XXsHfQ14DPB5mkXnT2wnlLsReCpwyiAXrarr2rdLaBLRbwf5vCRp\nOLomgX8A7gZQVe9OsgR4Ds3kcf8MvHGQiybZjGY08n2B91WVs5BK0hh0HSx2BXDFtO13sAldQqvq\nFmDvJEuBM5LsX1Vfn3nccStO2NhLSNKiNzU1xdTU1CadI1XjXTAsyRuB66rqhBn765pTLr91e+lh\nuzDuWCVpPktCVWXDR64z1yyi7xngPFVVR3Q5MMndgBur6uokWwFPAI4d4FqSpCGZ63HQs+i+rnAB\nnZIAcHfgI2lmpdsM+GhVndnxs5KkIZprFtGd+7hgVV1I061UkjRmg6wsJklaZDongSR3THJ4ko8l\n+XKSPdr9z0pyv/5ClCT1pessovcAzqLp138JzUpjS9viJwEHA4f3EaAkqT9dawIntMc+ENiLdVNJ\nQzOaeP8hxyVJGoGuI4YPAl5aVf+3XVxmul8A9xxuWJKkUehaE1gC/G6WsjsDNw8nHEnSKHVNAj8E\nnj5L2UHAucMJR5I0Sl0fB70L+HiSm4GPt/v2SHIQ8NfAs/sITpLUr64TyH0qyd2BfwT+pt39SeAP\nwN9V1Wk9xSdJ6lHXmgBV9X+SnAI8FtgR+A3wjapyLQBJWqA2mASSbAl8BPiXqvoW8O+9RyVJGokN\nNgxX1Q3AU4CZXUMlSQtc195B3wUe0WcgkqTR69omcCSwIslvgRVVdWWPMUmSRqRrTeB84N7A+4HV\nSW5McsO015r+QpQk9aVrTeAEui8wI0laILqOEziq70AkSaO3wcdBSbZM8sskTxlFQJKk0enaRXRL\n4Pr+w5EkjVLXhuHTaBaelyQtIl0bhj8HvDfJUmAFsIoZDcVV9e0hxyZJ6lnXJPDF9ufz29f0BJB2\n2xHFkrTAdE0Ch/QahSRpLLp2ET2970AkSaPXeSppgCR3pplDaDvgKuDsqvp9H4FJkvrXOQkkeQNw\nFLAVTTsAwHVJ3lpVb+kjOElSvzolgSRHAG8ClgMfA64AdgYOBd6U5Kqqem9vUUqSetG1JvAy4D1V\n9bJp+34AnJ7kauDlgElAkhaYroPF7gOcOkvZqW15J0l2SXJWkouSXJjkFV0/K0karq5J4CrgAbOU\nPaAt7+om4FVVtRfwKOCIJHsO8HlJ0pB0TQIrgLck+bMkaxuFSfJM4M1teSdVdUVVnd++vxa4GLhn\n95AlScPStU3gKGAf4FPAmiS/AnYAlgDntOUDS7I78BCa5SslSSPWdbDY1UkeDTwTeCzrxgl8HTi1\nqm4e9MJJ7gR8FjiyrRHcznErThj0tJI0Maamppiamtqkc6Rq9AuGJdkC+Hfgy1V10izH1DWnXH7r\n9tLDdmEcsUrSQpGEqsqGj1xn1jaBJDskWZ7k4DmOOaQ9ZrtBLgp8CFg5WwKQJI3GXA3Dr6CZIuKr\ncxzzVeDhNOMEOkmyH/AXwAFJzkty7lyJRpLUn7naBJ4KvH+u5/1VdVOS99N8qR/b5YJV9V847bQk\nzQtz1QTuB5zb4RznAfcfTjiSpFHa0DiBWzqco1g3oZwkaQGZKwlcCuzd4Rx7A5cNJRpJ0kjNlQT+\nA3hlkm1nOyDJXYEjaRailyQtMHMlgXcAWwLfaruC3tqYm2TzJIcA3wLuALyz3zAlSX2YtXdQVf06\nyUHAF2gGdq1JsqotvjvNlBE/BQ6qql/3HqkkaejmbBiuqguABwIvAj5D8+z/svb9i4AHVdWF/YZ4\nW7vfazeS3Pra/V67jfLykrSobHDuoKq6Afho+xq7yy7/GTOnk5AkbZyuU0lLkhYhk4AkTTCTgCRN\nMJOAJE0wk4AkTbBFlQTsPipJg5m1i2iSLw1wnqqqJw8hnk1i91FJGsxc4wS2o5khdFHY/V67cdnl\nP7t1e7ddduXSnzvvnaTJNte0EfuOMpC+WUuQpNtbVG0CG8N2BEmTbIPTRkyXZBvgvsAdZ5ZV1dnD\nCmqUrCFImmSdkkCSLYH3AYcy+/rArhssSQtM18dBRwNPBl5Ks5Tkq4GXAecAPwGe1Ut0kqRedU0C\nzwHeBHy43f5GVb23bTxeCfxpD7FJknrWNQnsBlxYVTcDNwJbTyv7APD8YQc2H9hoLGmx65oEfgPc\nuX1/OfDgaWXbAtsMM6j5Ym2j8drX9HEGJghJi0HX3kHnAH9Cs/j8CuBNSZYANwFHAd/uJ7z5y15F\nkhaDrkng7cDu7fs3A3vSLC4f4HzgiKFHJknqXafHQVX1nar6ZPv+d+08QdsCO1fVPlX1kz6DXEh8\nTCRpIemUBJK8JsnO0/dV1e+r6ldJdkrymn7CW3hsR5C0kHRtGH4rsOssZbu05Z0kOTnJ6iQXdP3M\nYmGCkDTfdG0TyBxldwFuGOCapwD/BPzbAJ9Z9GxoljQOc60n8BhuOwjsRUkeP+OwrYCnAxd3vWBV\nfSuJf+YOwGmwJfVlrprAgcAx7fsCXrKeYwr4Mc0UEurJbLWEuZKDiUNSF3MlgX8Ejqd5FHQdTa3g\nnBnH3FBVi2bhmYVmrkdIc5WZICStNdeiMjcDNwMk2aqq1owsqtZxK04Y9SUnwsbULCTNP1NTU0xN\nTW3SOTo1DFfVmnaE8AuA/WmWnrwK+BqwfCMSRJi7sRmAo5/x6lvfH3/qiQNeQoPa2NqDyUMaj2XL\nlrFs2bJbt4899tiBz9F1PYEdgLOAvYDVwBXAPsBfAK9MckBVXdnxXB8HlgHbJ/kZcExVnTJw5Bqp\njX30JGl+69pF9G3A3YEnVNWZa3cmORD4RFv+4i4nqqpFOeOoJC1EXQeLPQV43fQEANBuv6Etl25j\nrgFwDo6T5oeuNYGlwM9mKbusLZduY9i9l2bun14maeN0TQL/DTwPOH09Zc9py6WhmC1BzNw/vczG\naWnjdE0CJwIntw3Ey4FVwM7Ac2keBXVqD5D64rgIaeN0nUr6FOCVwCOBjwH/SZMM9gNeWVUf7itA\naVNtzMR9tmdoUnStCVBV707yXuCPWDdO4IdVdWNfwUl96/roadjtGV3HWViLUd/mmkDuEuCZVfWD\ntfvaL/zzRhGYtBANO6kMe94ok4pmmqsmsDuwZERxSBrAsJMKbFwtRgtf58dBkha3janFaOHbUMOw\nM4RKmtXGNKBvbKO7DfL92FBN4NgkXeYEqqr6y2EEJGnh2JhHT308ytLG21ASeAjQZYZQawyStABt\nKAk8o6rOHkkkkqSR6zqBnCTNS7YjbBp7B0la0GxH2DTWBCRpgs2aBKpqM9sDJC1Wo+zeOp/5OEjS\nRBpl99b5zMdBkjTBTAKS1LONebw0Kj4OkqSezed5mawJSNI8NKpagjUBSZqHRrVkqklAkhaYYT5G\n8nGQJE0wk4AkTTCTgCRNMJOAJE2wsSSBJAcn+VGS/07y2nHEIEkaQxJIshnwz8BBwF7A85LsOeo4\nJEnjqQk8Avifqrqsqm4EPgk8fQxxSNLEG0cSuCfw82nbl7f7JEkjZsOwJE2wVNVoL5jsC/zvqjq4\n3T4KqKp624zjRhuYJC0CVZVBjh9HEtgc+DFwILAKOBt4XlVdPNJAJEmjnzuoqm5O8jLgDJrHUSeb\nACRpPEZeE5AkzR/zrmF4kgeSJTk5yeokF0zbd9ckZyT5cZLTk9xlnDGOSpJdkpyV5KIkFyZ5Rbt/\n4u5HkiVJvpvkvPZ+HNfun7h7Ac1YoyTnJvliuz2R9wEgyaVJftD+2zi73TfQ/ZhXScCBZJxC87tP\ndxTwn1X1AOAs4HUjj2o8bgJeVVV7AY8Cjmj/LUzc/aiqNcDjqmpv4MHAAUn2YwLvRetIYOW07Um9\nDwC3AMuqau+qekS7b6D7Ma+SABM+kKyqvgX8dsbupwMfad9/BHjGSIMak6q6oqrOb99fC1wM7MLk\n3o/r2rdLaP7f/pYJvBdJdgGeBPzrtN0Tdx+mCbf/Hh/ofsy3JOBAstvbsapWQ/PFCOw45nhGLsnu\nwEOA7wA7TeL9aB+BnAdcAUxV1Uom816cCPw9ML0xcxLvw1oFfDXJOUn+qt030P1wZbGFZ6Ja8pPc\nCfgscGRVXbue8SMTcT+q6hZg7yRLgdOTLOP2v/uivhdJngysrqrz299/Nov6PsywX1WtSrIDcEaS\nHzPgv4v5VhP4BbDrtO1d2n2TbHWSnQCS7Az8aszxjEySLWgSwEer6tR298TeD4Cqugb4EvAwJu9e\n7Ac8LcklwCdo2kY+ClwxYffhVlW1qv35a2AFzSP1gf5dzLckcA6wR5LdkmwJPBf44phjGrW0r7W+\nCLyoff+XwKkzP7CIfQhYWVUnTds3cfcjyd3W9vBIshXwBOA8JuxeVNXRVbVrVd2H5rvhrKp6AXAa\nE3Qf1kqydVtTJsk2wBOBCxnw38W8GyeQ5GDgJNYNJDt+zCGNTJKPA8uA7YHVwDE02f0zwL2Ay4A/\nr6rfjSvGUWl7v3yD5h91ta+jaUaYf5oJuh9J/pimgW9tI+BHq+qdSbZjwu7FWkn2B15dVU+b1PuQ\n5N7AF2j+b2wBLK+q4we9H/MuCUiSRme+PQ6SJI2QSUCSJphJQJImmElAkiaYSUCSJphJQJImmElA\ni1aSWzq8Lunp2p9IsnLDR0rj5dxBWsz2nbG9AjifZhDe2lHZa3q69uuBbXo6tzQ0JgEtWlV19vTt\nJGuAK6vqnBFcu5cahjRsPg6SWkkOS3JBkuuT/CrJh9rZGacfsyrJB5O8NMlPkvwhydlJHjPjuE8m\nuXjGvjsleWf7ueuT/DLJp5LcdRS/n7Q+JgEJaJevPBk4l2ZRjtcDTwPOSrJkxuEHAS+hmdf+eTRz\nt3wlyW7Tjlk739Ha8y8BpoDDgQ/QLIzycuD3wNLh/0ZSNz4O0sRLcgfgH4AvV9WLpu2/BPgq8AJu\nu5LV9sBD2+l7STJFM1HX0cD/muUyLwb2Bp5YVWdO2/+54fwW0saxJiDBHwHbAcun72y/rFcD+884\n/ptrE0B73O+A02nWQp7NE4DLZiQAaexMAlKTAApYtZ6yK9ry6Vav57jVzL0U6vY0y6VK84pJQIKr\naLqM7ryesp3b8ul2Ws9xOzH3KnhX4nrZmodMAhL8kOaL/rnTdyY5kObL/Wszjn9skh2nHXdXmsbi\nb89xjTOA3dtzSvOGSUATr6puBI4FntJ2Cz0oyeE069j+kBltBTR/1X81ybOTPIvmC35z4Lg5LnMK\nTc+jzyV5bZIDkjwryQdm9CqSRsreQZokt+m2eZuCqn9K8nvgb2m6fV5Ds3bta6tq5qji02m+0N8O\n3B24gKbXz8/Wc72151+T5HE0yeal7c8rgW8CV2/i7yVtNJeXlAaQZBVwWlUdPu5YpGHwcZAkTTCT\ngDSYWR8pSQuRj4MkaYJZE5CkCWYSkKQJZhKQpAlmEpCkCWYSkKQJZhKQpAn2/wG9q4PGsQi8WAAA\nAABJRU5ErkJggg==\n",
-       "text": [
-        "<matplotlib.figure.Figure at 0x11bba358>"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "heading",
-     "level": 3,
-     "metadata": {},
-     "source": [
-      "Pointwise Document TC"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can decompose total correlation further. The topic correlation is the average of the pointwise total correlations for each individual document. The pointwise total correlations can be accessed through **log_z**."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "topic_model.log_z.shape # n_docs x k_topics"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 20,
-       "text": [
-        "(11314L, 50L)"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print np.mean(topic_model.log_z, axis = 0)\n",
-      "print topic_model.tcs"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[ 5.50936875  1.71880547  1.52174746  1.48466938  1.42693583  1.29085193\n",
-        "  1.26609881  1.1708247   1.16042462  1.13640408  1.07429588  1.05070165\n",
-        "  1.03974055  1.01012143  1.00165842  0.96016033  0.95542024  0.87962434\n",
-        "  0.87349373  0.86021641  0.84504486  0.83115173  0.78774316  0.78638255\n",
-        "  0.77723307  0.77611457  0.75923648  0.75624978  0.75302028  0.74406531\n",
-        "  0.73381027  0.72874046  0.72664691  0.70655913  0.69218346  0.65247412\n",
-        "  0.64374397  0.64284665  0.64184489  0.63527819  0.54535081  0.54242174\n",
-        "  0.46340101  0.45849674  0.45766116  0.44362281  0.37530433  0.36277463\n",
-        "  0.30876452  0.29219639]\n",
-        "[ 5.50936875  1.71880547  1.52174746  1.48466938  1.42693583  1.29085193\n",
-        "  1.26609881  1.1708247   1.16042462  1.13640408  1.07429588  1.05070165\n",
-        "  1.03974055  1.01012143  1.00165842  0.96016033  0.95542024  0.87962434\n",
-        "  0.87349373  0.86021641  0.84504486  0.83115173  0.78774316  0.78638255\n",
-        "  0.77723307  0.77611457  0.75923648  0.75624978  0.75302028  0.74406531\n",
-        "  0.73381027  0.72874046  0.72664691  0.70655913  0.69218346  0.65247412\n",
-        "  0.64374397  0.64284665  0.64184489  0.63527819  0.54535081  0.54242174\n",
-        "  0.46340101  0.45849674  0.45766116  0.44362281  0.37530433  0.36277463\n",
-        "  0.30876452  0.29219639]\n"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "These values represent the correlations explained by a topic for an individual document."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Hierarchical Topic Models"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can naturally repeat the CorEx algorithm on the topics to get latent representations of the topics themselves. This yields a hierarchical CorEx topic model. Like the first layer of the topic model, one can determine the number of latent variables to add in higher layers through examination of the topic TCs."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Train a second layer to the topic model\n",
-      "tm_layer2 = ct.Corex(n_hidden=10)\n",
-      "tm_layer2.fit(topic_model.labels);\n",
-      "\n",
-      "# Train a third layer to the topic model\n",
-      "tm_layer3 = ct.Corex(n_hidden=1)\n",
-      "tm_layer3.fit(tm_layer2.labels);"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "WARNING: Some words never appear (or always appear)\n"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "If you have graphviz installed, then you can output visualizations of the hierarchial topic model to your current working directory. One can also create custom visualizations of the hierarchy by properly making use of the **labels** attribute of each layer."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "vt.vis_hierarchy([topic_model, tm_layer2, tm_layer3], column_label=starred_words, max_edges=200, prefix='topic-model-example')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Anchoring for Semi-Supervised Topic Modeling"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Anchored CorEx is an extension of CorEx that allows the \"anchoring\" of words to topics. When anchoring a word to a topic, CorEx is trying to maximize the mutual information between that word and the anchored topic. So, anchoring provides a way to guide the topic model towards specific subsets of words that the user would like to explore. The anchoring mechanism is flexible, and so there are many possibilities of anchoring:\n",
-      "+ anchoring one word to one topic\n",
-      "+ anchoring a group of words to one topic\n",
-      "+ anchoring one word to multiple topics\n",
-      "+ anchoring multiple groups of words to individual topics\n",
-      "+ anchoring to some topics and not others\n",
-      "\n",
-      "We'll demonstrate how easy it is to anchor the CorEx topic model."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Anchor one word to the first topic\n",
-      "anchor_words = ['nasa']"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Anchor the word 'nasa' to the first topic\n",
-      "anchored_topic_model = ct.Corex(n_hidden=50)\n",
-      "anchored_topic_model.fit(doc_word, words=words, anchors=anchor_words, anchor_strength=6);"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "This anchors the single word \"nasa\" to the first topic."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "topic_words,_ = zip(*anchored_topic_model.get_topics(topic=0))\n",
-      "print '0:' + ','.join(topic_words)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "0:nasa,space,gov,center,published,organization,addition,independent,march,institute\n"
-       ]
-      }
-     ],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We can anchor multiple groups of words to multiple topics as well."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Anchor 'nasa' and 'space' to first topic, 'sports' and 'stadium' to second topic, so on...\n",
-      "anchor_words = [['nasa', 'space'], ['sports', 'stadium'], ['politics', 'government'], ['love', 'hope']]\n",
-      "\n",
-      "anchored_topic_model = ct.Corex(n_hidden=50)\n",
-      "anchored_topic_model.fit(doc_word, words=words, anchors=anchor_words, anchor_strength=6);"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for n in range(len(anchor_words)):\n",
-      "    topic_words,_ = zip(*anchored_topic_model.get_topics(topic=n))\n",
-      "    print '{}: '.format(n) + ','.join(topic_words)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "0: space,nasa,orbit,gov,shuttle,launch,moon,earth,lunar,ames\n",
-        "1: sports,stadium,team,game,season,players,play,league,games,hockey"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "2: government,politics,law,state,rights,war,country,military,states,united"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "3: hope,love,helps,rit,ultb,relates,virile,tatoos,sustaining,snm6394"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Note, in the above topic model, topics will no longer be sorted according to descending TC. Instead, the first topic will be the one with \"nasa\" and \"space\" anchored to it, the second topic will be the one with \"sports\" and \"stadium\" anchored to it, and so on.\n",
-      "\n",
-      "We can continue to develop even more complicated anchoring strategies. Here we anchor \"nasa\" by itself, as well as in two other topics each with \"politics\" and \"news\" to find different aspects around the word \"nasa\". We also create a fourth anchoring of \"happy\" and \"love\" to a topic."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Anchor with single words and groups of words\n",
-      "anchor_words = ['nasa', ['nasa', 'politics'], ['nasa', 'news'], ['happy', 'love']]\n",
-      "\n",
-      "anchored_topic_model = ct.Corex(n_hidden=50)\n",
-      "anchored_topic_model.fit(doc_word, words=words, anchors=anchor_words, anchor_strength=6);"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for n in range(len(anchor_words)):\n",
-      "    topic_words,_ = zip(*anchored_topic_model.get_topics(topic=n))\n",
-      "    print '{}: '.format(n) + ','.join(topic_words)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "0: nasa,space,orbit,launch,shuttle,earth,moon,lunar,satellite,mission\n",
-        "1: nasa,politics,gov,ames,shafer,dryden,jet,balls,iftccu,gothamcity"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "2: news,nasa,insisting,pasadena,advertising,edwards,hal,nbc,llnl,exploiting"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "3: love,happy,tatoos,virile,relates,wicked,whosoever,wilt,mozumder,canal"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "**Note:** If you do not specify the column labels through **words**, then you can still anchor by specifying the column indices of the features you wish to anchor on. You may also specify anchors using a mix of strings and indices if desired."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "**Choosing anchor strength:** the anchor strength controls how much weight CorEx puts towards maximizing the mutual information between the anchor words and their respective topics. Anchor strength should always be set at a value *greater than* 1, since setting anchor strength between 0 and 1 only recovers the unsupervised CorEx objective. Empirically, setting anchor strength from 1.5-3 seems to nudge the topic model towards the anchor words. Setting anchor strength >5 is strongly enforcing that the CorEx topic model find a topic associated with the anchor words.\n",
-      "\n",
-      "We encourage users to experiment with the anchor strength and determine what values are best for their needs."
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Other Output"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The *vis_topic* module provides support for outputting topics and visualizations of the CorEx topic model. The code below creates a results direcory named \"twenty\" in your working directory."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "vt.vis_rep(topic_model, column_label=words, prefix='twenty')"
-     ],
-     "language": "python",
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Anchored CorEx: Topic Modeling with Minimal Domain Knowledge"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Author:** [Ryan J. Gallagher](http://ryanjgallagher.github.io/)  \n",
+    "\n",
+    "**Last updated:** 01/02/2018"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook walks through how to use the CorEx topic model code. This includes fitting CorEx to your data, examining the topic model output, outputting results, building a hierarchical topic model, and anchoring words to topics. It is assumed that `corex_topic.py` and `vis_topic.py` are in your working directory, and that you have numpy, scipy, and scikit-learn installed. \n",
+    "\n",
+    "Details of the CorEx topic model and evaluations against unsupervised and semi-supervised variants of LDA can be found in our TACL paper:\n",
+    "\n",
+    "[*Anchored Correlation Explanation: Topic Modeling with Minimal Domain Knowledge*](hhttps://www.transacl.org/ojs/index.php/tacl/article/view/1244), Gallagher et al., TACL 2017."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# If you haven't moved out of the examples directory\n",
+    "import os\n",
+    "os.chdir('..')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import vis_topic as vt\n",
+    "import corex_topic as ct\n",
+    "import scipy.sparse as ss\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from sklearn.datasets import fetch_20newsgroups\n",
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading the 20 Newsgroups Dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to first load data to run the CorEx topic model. We'll use the 20 Newsgroups dataset, which scikit-learn provides functionality to access."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get 20 newsgroups data\n",
+    "newsgroups = fetch_20newsgroups(subset='train', remove=('headers', 'footers', 'quotes'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The topic model assumes input is in the form of a doc-word matrix, where rows are documents and columns are binary counts. We'll vectorize the newsgroups data, take the top 20,000 words, and convert it to a sparse matrix to save on memory usage. Note, we use binary count vectors as input to the CorEx topic model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(11314, 20000)"
+      ]
+     },
+     "execution_count": 4,
      "metadata": {},
-     "outputs": []
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Transform 20 newsgroup data into a sparse matrix\n",
+    "vectorizer = CountVectorizer(stop_words='english', max_features = 20000, binary = True)\n",
+    "doc_word = vectorizer.fit_transform(newsgroups.data)\n",
+    "doc_word = ss.csr_matrix(doc_word)\n",
+    "\n",
+    "doc_word.shape # n_docs x m_words"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our doc-word matrix is 11,314 documents by 20,000 words. Let's get the words that label the columns. We'll need these for outputting readable topics and later for anchoring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Get words that label the columns (needed to extract readable topics and make anchoring easier)\n",
+    "words = list(np.asarray(vectorizer.get_feature_names()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll do a final step of preprocessing where we remove all integers from our set of words. This brings is down to 19,038 words."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(11314, 19038)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "not_digit_inds = [ind for ind,word in enumerate(words) if not word.isdigit()]\n",
+    "doc_word = doc_word[:,not_digit_inds]\n",
+    "words    = [word for ind,word in enumerate(words) if not word.isdigit()]\n",
+    "\n",
+    "doc_word.shape # n_docs x m_words"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CorEx Topic Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The main paramters of the CorEx topic model are:\n",
+    "+ `n_hidden`: number of topics (\"hidden\" as in \"hidden latent topics\")\n",
+    "+ `words`: words that label the columns of the doc-word matrix (optional)\n",
+    "+ `max_iter`: number of iterations to run through the update equations\n",
+    "+ `verbose`:  if `verbose=1`, then CorEx will print the topic TCs with each iteration\n",
+    "+ `seed`:     random number seed to use for model initialization\n",
+    "\n",
+    "We'll train a topic model with 50 topics. (This will take a few minutes.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Train the CorEx topic model with 50 topics\n",
+    "topic_model = ct.Corex(n_hidden=50, words=words, max_iter=200, verbose=False, seed=1)\n",
+    "topic_model.fit(doc_word, words=words);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CorEx Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The CorEx topic model provides functionality for easily accessing the topics. Let's take a look one of the topics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('team', 0.076051187926834227),\n",
+       " ('game', 0.066667541279824744),\n",
+       " ('season', 0.048879938425177287),\n",
+       " ('players', 0.047344267714412643),\n",
+       " ('league', 0.043708887910980376),\n",
+       " ('play', 0.043335932010217425),\n",
+       " ('hockey', 0.042396968873452616),\n",
+       " ('games', 0.039692707277392415),\n",
+       " ('teams', 0.036825328401630691),\n",
+       " ('nhl', 0.03191145093230828)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Print a single topic from CorEx topic model\n",
+    "topic_model.get_topics(topic=1, n_words=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The topic words are those with the highest *mutual information* with the topic, rather than those with highest probability within the topic as in LDA. The mutual information with the topic is the number reported in each tuple. Theoretically, mutual information is always positive. If the CorEx output returns a negative mutual information from `get_topics()`, then the absolute value of that quantity is the mutual information between the topic and the *absence* of that word.\n",
+    "\n",
+    "If the column labels have not been specified through `words`, then the code will return the column indices for the top words in each topic.\n",
+    "\n",
+    "We can also retrieve all of the topics at once if we would like."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: dsl,n3jxp,chastity,cadre,geb,shameful,intellect,skepticism,banks,pitt\n",
+      "1: team,game,season,players,league,play,hockey,games,teams,nhl\n",
+      "2: government,law,public,rights,state,encryption,clipper,federal,security,secure\n",
+      "3: god,jesus,bible,christians,christian,christ,religion,jews,church,faith\n",
+      "4: people,say,fact,point,believe,person,saying,world,reason,mean\n",
+      "5: armenians,armenian,national,international,argic,press,policy,serdar,soviet,armenia\n",
+      "6: file,program,window,directory,ftp,pub,server,application,unix,available\n",
+      "7: based,issue,sense,clear,truth,subject,certain,known,particular,existence\n",
+      "8: cs,ma,au,gmt,cc,uu,id,sites,fi,host\n",
+      "9: windows,software,card,thanks,pc,dos,files,disk,advance,ram\n",
+      "10: drive,sale,scsi,controller,board,shipping,ide,drives,cd,bus\n",
+      "11: pitching,hit,staff,braves,runs,hitter,nl,smith,hr,baltimore\n",
+      "12: just,don,like,time,going,right,better,let,come,didn\n",
+      "13: archive,various,document,related,addition,modified,published,contents,complete,distributed\n",
+      "14: information,internet,university,systems,send,following,address,phone,contact,computer\n",
+      "15: year,april,san,york,los,washington,north,angeles,city,california\n",
+      "16: war,country,children,killed,military,population,society,live,soldiers,anti\n",
+      "17: space,nasa,orbit,earth,moon,launch,shuttle,lunar,mission,flight\n",
+      "18: life,sin,words,mind,spirit,born,father,follow,accept,son\n",
+      "19: pp,special,van,berkeley,journal,ai,mark,mu,la,vol\n",
+      "20: years,away,later,left,came,days,old,ago,took,gave\n",
+      "21: disease,medical,doctor,patients,food,cause,treatment,medicine,blood,health\n",
+      "22: provide,questions,provides,developed,specific,development,standard,require,appropriate,commercial\n",
+      "23: given,number,note,end,present,taken,according,purpose,numbers,major\n",
+      "24: key,keys,data,algorithm,details,des,process,contains,users,provided\n",
+      "25: members,turkish,involved,army,organizations,troops,received,organization,land,fighting\n",
+      "26: read,different,example,does,word,having,groups,written,book,try\n",
+      "27: united,states,american,force,individual,independent,arms,community,nation,forces\n",
+      "28: death,human,said,evidence,crime,self,kill,lives,murder,killing\n",
+      "29: new,including,sent,single,department,short,news,ii,school,placed\n",
+      "30: use,using,work,used,need,run,problems,line,help,type\n",
+      "31: large,small,control,needed,outside,local,light,parts,useful,ground\n",
+      "32: general,important,far,course,non,times,actually,consider,likely,result\n",
+      "33: think,way,good,things,really,know,did,thing,ve,probably\n",
+      "34: problem,set,place,called,change,trying,return,open,support,instead\n",
+      "35: man,history,today,women,went,told,coming,happened,stand,knew\n",
+      "36: second,john,period,1st,2nd,3rd,points,goal,ed,followed\n",
+      "37: bike,ride,engine,riding,dod,bikes,miles,motorcycle,rear,honda\n",
+      "38: drivers,mode,mb,faster,interface,os,driver,hp,color,fast\n",
+      "39: gun,guns,weapons,firearms,defense,weapon,batf,armed,assault,shooting\n",
+      "40: high,power,low,current,model,al,lower,higher,series,average\n",
+      "41: ways,dr,break,passed,kinds,reach,mass,larry,content,stands\n",
+      "42: wide,included,volume,remote,bit,pages,notes,fully,fields,operations\n",
+      "43: long,day,especially,situation,rest,body,century,ones,family,worse\n",
+      "44: make,want,real,case,possible,order,quite,free,able,ask\n",
+      "45: car,money,cars,pay,tax,road,deal,insurance,worth,dollars\n",
+      "46: drug,certainly,considered,taking,effective,expect,generally,social,child,purposes\n",
+      "47: necessary,strong,prevent,required,plan,safe,carefully,attention,aside,unique\n",
+      "48: little,wants,takes,comes,lead,trouble,looks,pass,capable,unfortunately\n",
+      "49: bring,brought,happy,charge,smart,improve,shows,england,cast,belong\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print all topics from the CorEx topic model\n",
+    "topics = topic_model.get_topics()\n",
+    "for n,topic in enumerate(topics):\n",
+    "    topic_words,_ = zip(*topic)\n",
+    "    print('{}: '.format(n) + ','.join(topic_words))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, the first topic looks a bit odd, but these characters were used frequently to encode images. The CorEx topic model picks up on these encodings as a topic since they were not cleaned from the data.\n",
+    "\n",
+    "We can also get the column indices instead of the column labels if necessary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(1336, 0.037197519799330066),\n",
+       " (1335, 0.036085671214321713),\n",
+       " (11448, 0.035316037193370863),\n",
+       " (8968, 0.030759815671340549),\n",
+       " (1306, 0.029126522278008646),\n",
+       " (13303, 0.027771307085387921),\n",
+       " (13051, 0.027594397620650163),\n",
+       " (15437, 0.026729063880204122),\n",
+       " (16092, 0.026121923976488198),\n",
+       " (1334, 0.025890341850722261)]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topic_model.get_topics(topic=5, n_words=10, print_words=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we need to directly access the topic assignments for each word, they can be accessed through `cluster`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 8  9 38 ..., 37  0  0]\n",
+      "(19038,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(topic_model.clusters)\n",
+    "print(topic_model.clusters.shape) # m_words"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Document Labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "CorEx is a *discriminative* model, whereas LDA is a *generative* model. This means that while LDA outputs a probability distribution over each document, CorEx instead estimates the probability a document belongs to a topic given that document's words. As a result, the probabilities across topics for a given document do not have to add up to 1. The estimated probabilities of topics for each document can be accessed through `p_y_given_x`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(11314, 50)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(topic_model.p_y_given_x.shape) # n_docs x k_topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also use a softmax to make a binary determination of which documents belong to each topic. These softmax labels can be accessed through `labels`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(11314, 50)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(topic_model.labels.shape) # n_docs x k_topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since CorEx does not prescribe a probability distribution of topics over each document, this means that a document could possibly belong to no topics (all 0's across topics in `labels`) or all topics (all 1's across topics in `labels`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Total Correlation and Model Selection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Overall TC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Total correlation is the measure which CorEx tries maximize when constructing the topic model. It can be accessed through `tc` and is reported in nats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "44.547808454612763"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topic_model.tc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Model selection:** CorEx starts its algorithm with a random initialization, and so different runs can result in different topic models. One way of finding a better topic model is to restart the CorEx algorithm several times and take the run that has the highest TC value (i.e. the run that produces topcis that are most informative about the documents)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Topic TC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The overall total correlation is the sum of the total correlation per each topic. These can be accessed through `tcs`. For an unsupervised CorEx topic model, the topics are always sorted from high to low according to their TC. For an anchored CorEx topic model, the topics are not sorted, and are outputted such that the anchored topics come first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(50,)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topic_model.tcs.shape # k_topics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "44.5478084546\n",
+      "44.5478084546\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.sum(topic_model.tcs))\n",
+    "print(topic_model.tc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Selecting number of topics:** one way to choose topics is to observe the distribution of TCs for each topic to see how much each additional topic contributes to the overall TC. We should keep adding topics until additional topics do not significantly add to the overall TC. This is similar to choosing a cutoff eigenvalue when doing topic modeling via LSA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x11119a518>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmkAAAFFCAYAAAC393oCAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xm4JXV95/H3Z5pVxCDQCrLYJqJGHQPaAUyiMiiySCQx\nGNFoNKNhXHCJGgOMg4HEDbfoEBcCCi4RjAuggkiUBJkEsEEWgZhBlAiyNIsIAzaC3/mjqtPHy92K\ne8651fe8X89znltVv1/X+d6nHi8ff1X1+6WqkCRJUr/8l8UuQJIkSfdnSJMkSeohQ5okSVIPGdIk\nSZJ6yJAmSZLUQ4Y0SZKkHjKkSZIk9ZAhTZIkqYcMaZIkST20wWIXMAxbb711rVixYrHLkCRJmtOF\nF154c1Utn6vfkghpK1asYNWqVYtdhiRJ0pySXDOfft7ulCRJ6iFDmiRJUg8Z0iRJknrIkCZJktRD\nhjRJkqQeMqRJkiT1kCFNkiSphwxpkiRJPWRIkyRJ6iFDmiRJUg8Z0iRJknpoSazdOS4HHH7S/Y6d\n+o6DFqESSZK01DmSJkmS1EOGNEmSpB4ypEmSJPWQIU2SJKmHDGmSJEk9ZEiTJEnqobGGtCSbJLkg\nySVJLk9y5DR9XpZkdZKL288rxlmjJElSH4x7nrQ1wJ5VdWeSDYFzk5xRVedN6XdyVR0y5tokSZJ6\nY6whraoKuLPd3bD91DhrkCRJWh+M/Zm0JMuSXAzcBJxVVedP0+0Pklya5PNJdpjhPAcnWZVk1erV\nq0dasyRJ0riNPaRV1X1VtTOwPbBrkidO6fJlYEVVPQk4CzhxhvMcW1Urq2rl8uXLR1u0JEnSmC3a\n251V9RPgbGCfKcdvqao17e5xwFPGXZskSdJiG/fbncuTbNFubwrsBfzblD7bDuw+F7hyfBVKkiT1\nw7jf7twWODHJMpqA+Lmq+kqSo4BVVXUa8LokzwXuBW4FXjbmGiVJkhbduN/uvBTYZZrjRwxsHwYc\nNs66JEmS+sYVByRJknrIkCZJktRDhjRJkqQeMqRJkiT1kCFNkiSphwxpkiRJPWRIkyRJ6iFDmiRJ\nUg8Z0iRJknrIkCZJktRDhjRJkqQeMqRJkiT1kCFNkiSphwxpkiRJPWRIkyRJ6iFDmiRJUg9tMN+O\nSZYBvwnsDjwC2BS4GfgecE5V/XgkFUqSJE2gOUNakh2B1wF/DGwFBLi7/WxBMxpXSf4P8GHg5Kqq\nkVUsSZI0AWa93ZnkfcC/A3sBHwCeDjy4qjarqq2ragPgUcCLgB8CxwIXJ3nKSKuWJEla4uYaSXs8\nsEdVnTdTh6q6BrgGODnJZsBrgN2AC4dWpSRJ0oSZNaRV1b5dTlZV/w84ekEVSZIkybc7JUmS+mje\nIS3JfklePLC/XZKzk6xO8ukkDxpNiZIkSZOny0ja24DtB/Y/ADwO+BywL3DEEOuSJEmaaF1C2qOB\nSwCSbALsD7yxql4DHAYcOPzyJEmSJlOXkLYpcFe7/VRgI+Br7f6VNBPcSpIkaQi6hLRraFYbAPhd\n4KKquq3dXw7cMczCJEmSJlmXkHY8cFSSc4HXAp8YaNudZjRtVkk2SXJBkkuSXJ7kyGn6bJzk5CRX\nJTk/yYoONUqSJC0J8167s6rem+Q2mkD2SeDvBpqXA5+ax2nWAHtW1Z1JNgTOTXLGlMlyXw7cVlWP\nTnIQ8G7gBfOtU5IkaSnossD6w4ATqur4aZpfQbOu56zaNT3vbHc3bD9T1/k8APjLdvvzwDFJ4nqg\nkiRpknS53Xk9MNOanDu37XNKsizJxcBNwFlVdf6ULtsBPwKoqnuB25kmACY5OMmqJKtWr149z19B\nkiRp/dAlpGWWtg2AX8znJFV1X1XtTDPn2q5JntihhsHzHFtVK6tq5fLlyx/IKSRJknpr1tudSR4M\nPGTg0NZJpk61sSnwIuDGLl9cVT9JcjawD/DdgabrgB2Aa5NsAPwKcEuXc0uSJK3v5nom7U2sW0mg\ngC/P0C/A2+f6siTLgZ+3AW1TYC+aFwMGnQa8FPhXmglyv+nzaJIkadLMFdK+AtxAE8I+DBwN/GBK\nnzXAFVV1wTy+b1vgxCTLaG61fq6qvpLkKGBVVZ1GM9XHp5JcBdwKHDTv30aSJGmJmDWkVdWFwIUA\nSQr4QlXd/EC/rKouBXaZ5vgRA9s/A57/QL9DkiRpKegyT9rHRlmIJEmS1pl3SANI8hjgT4DHAptM\naa6qes6wCpMkSZpkXSazfQrwLZq3OHcEvgdsCTwM+DHwH6MoUJIkaRJ1mSftXcBXgZ1oXiR4cVVt\nA+zfnucvhl+eJEnSZOoS0n4DOIF1k9YuA6iq04F30Lz5KUmSpCHoEtI2Bu6oql/QTI3x8IG2K4An\nDbMwSZKkSdYlpF0NrF1t4HLgZQNtL6ZZi1OSJElD0OXtzjNoVgg4CXgn8OUktwL30iyA/ubhlydJ\nkjSZusyTdvjA9teSPI1m2aYHAV9rVwuQJEnSEHSaJ21QVZ0HnDfEWiRJktTq8kyaJEmSxqTLZLYb\nAG8CXkgzme10Kw5sNsTaJEmSJlaX253vAt4IfAP4JrBmJBVJkiSpU0g7CDiyqo4cVTGSJElqdHkm\n7SE0a3dKkiRpxLqEtDOA3xpVIZIkSVqny+3OdwOfSXIPcDrN0lC/pKp+PKzCJEmSJlmXkLaq/fku\nmhUHprNsYeVIkiQJuoW0VwM1qkIkSZK0TpdloT46ykIkSZK0jisOSJIk9dCsIS3J0Um26nLCJPsl\nOXBhZUmSJE22uUbSdgZ+mOTEJM9O8uDpOiV5XJI/T3Ip8CngrmEXKkmSNElmfSatqp6d5NnAm2nm\nSaskPwBW0ywL9VBgBbA5cDPwceA9VXW/6TkkSZI0f3O+OFBVXwe+nuSRwD7AbsAjaBZY/z7wVeAc\n4JtV9fMR1ipJkjQxurzdeQ3wsfYjSZKkERrr251JdkhydpIrklye5PXT9Nkjye1JLm4/R4yzRkmS\npD7oMpntMNwLvKmqLkqyOXBhkrOq6oop/b5VVfuPuTZJkqTeGOtIWlVdX1UXtdt3AFcC242zBkmS\npPXBok1mm2QFsAtw/jTNT01ySZIzkjxhhn9/cJJVSVatXr16hJVKkiSN36KEtHa+tS8Ab6iqn05p\nvgh4ZFX9BvC/gVOmO0dVHVtVK6tq5fLly0dbsCRJ0piNPaQl2ZAmoH2mqr44tb2qflpVd7bbpwMb\nJtl6zGVKkiQtqs4vDiTZGdiRZp60X1JVn5vj3wY4Hriyqt4/Q59tgBurqpLsShMkb+lapyRJ0vps\n3iEtyWOALwK/DmSaLgXMGtKA3wZeAlyW5OL22OE0oY+q+ihwIPCqJPcCdwMHVVXNt05JkqSloMtI\n2oeBhwB/DFxGsyxUJ1V1LtMHvME+xwDHdD23JEnSUtIlpO0KvLyq/mFUxUiSJKnR5cWBW4G7RlWI\nJEmS1ukS0j4EvLJ9+F+SJEkj1OV256bAE4BLk5xJM7I2qKrqnUOrTJIkaYJ1CWl/NbA93SoABRjS\nJEmShqDrSJokSZLGYN4hrao6T7khSZKkB+aBrDjwLOAZwJY0z6X9U1V9Y9iFSZIkTbIuKw48CDgV\n2JNmQtrbaSa3PTzJN4ADqurukVQpSZI0YbpMwfEOmmWdDgYeVFUPBTZr938LePvwy5MkSZpMXULa\ngcBbq+r4qvoZQFX9rKqOB94G/OEoCpQkSZpEXULacuDSGdouAbZeeDmSJEmCbiHtGmCfGdqe3bZL\nkiRpCLq83Xkc8K4kmwKfAa4HtgEOAl4DHDr88iRJkiZTl5D2HppQdgjwyoHj9wEfrKr3DrMwSZKk\nSdZlMtsC3pjk3TRvc66dJ+1fqurGEdUnSZI0kTpPZtsGsi+NoBZJkiS1Zg1pSXYFvltVd7Xbs6qq\nC4ZWmSRJ0gSbayTtPGB34IJ2u2bol7Zt2fBKkyRJmlxzhbR9gSvb7f2YOaRJkiRpiGYNaVV15sD2\n10ZfjiRJkqDDZLZJrkjyX2doe3ySK4ZXliRJ0mTrsuLA44BNZ2h7EPDYhZcjSZIk6BbSYOZn0p4E\n3L7AWiRJktSaawqO1wKvbXcL+HySNVO6bQo8Avj88MuTJEmaTHO93flj4MJ2+9HA94BbpvRZA1wB\nfGS4pUmSJE2uud7u/ALwBYAkAP+zqq4eQ12SJEkTbd7PpFXVCxca0JLskOTs9k3Ry5O8fpo+SfKh\nJFcluTTJkxfynZIkSeujTmt3JlkGPIvmTc5NpjRXVb1njlPcC7ypqi5KsjlwYZKzqmpw+o59gZ3a\nz240t1F361KnJEnS+m7eIS3Jw4F/Bh5D8xJB2qbBNz5nDWlVdT1wfbt9R5Irge1onmlb6wDgk1VV\nwHlJtkiybftvJUmSJkKXKTiOBv4fTUgL8HTg8cD7gO/TcZ60JCuAXYDzpzRtB/xoYP/a9tjUf39w\nklVJVq1evbrLV0uSJPVel5C2B81I2Q/a/bur6t+q6i3AKcC753uiJA+meSHhDVX10w41/KeqOraq\nVlbVyuXLlz+QU0iSJPVWl5C2HLi2qu6jGVHbYqDtTOCZ8zlJkg1pAtpnquqL03S5DthhYH/79pgk\nSdLE6BLSrgO2ard/AOw50PZkmvnSZpVmHo/jgSur6v0zdDsN+OP2Lc/dgdt9Hk2SJE2aLm93ng08\nDTgVOA74QLvg+s+B3wU+MY9z/DbwEuCyJBe3xw4HdgSoqo8CpwP7AVcBdwF/0qFGSZKkJaFLSDsC\n2Bqgqj6UZGPgBTSLqx8D/K+5TlBV57LurdCZ+hTwmg51SZIkLTnzDmlVdQNww8D+e5hjyg1JkiQ9\nMF2eSZMkSdKYzDqSluTDHc5VVeVtSkmSpCGY63bn8/jlFQVm47NkkiRJQzJrSKuqbcZViCRJktbx\nmTRJkqQe6hTSkmzSrpn56SRnJHl0e/x5SXYaTYmSJEmTZ95TcCR5BPBN4NeAq4FHAw9pm/cD9gEO\nHnaBkiRJk6jLSNr72v6/DjyBX56U9mzgGUOsS5IkaaJ1WXFgb+BVVXVVkmVT2q4DthteWZIkSZOt\ny0jaxsBPZmjbHLhv4eVIkiQJuoW07wIHzNC2N3DRwsuRJEkSdLvd+X7g75PcB/x9e+zRSfYG/hQ4\ncNjFSZIkTaouC6yfnGRb4K+BV7eHTwLuBt5cVV8eQX2SJEkTqctIGlX1N0k+ATwNeBhwC3BOVd02\niuIkSZIm1bxCWpKNgBOBv62qc4GvjLQqSZKkCTevFweq6h5gf2Dq1BuSJEkagS5vd54P7DqqQiRJ\nkrROl2fSXg+ckuQ24JSqunlENUmSJE28LiNpFwOPAj4G3Jjk50nuGfisGU2JkiRJk6fLSNr7gBpV\nIZIkSVqnyzxph46yEEmSJK0zr9udSTZK8uMk+4+6IEmSJHWbgmMj4GejLUeSJEnQ7Zm0LwPPA/5x\nRLUsGQccftL9jp36joMWoRJJkrS+6hLSvgB8JMlDgFOA65nyIkFV/csQa5MkSZpYXULaae3PF7Wf\nwYCWdn/WFQmSfJxm5YKbquqJ07TvAZwK/KA99MWqOqpDjZIkSUtCl5C27xC+7wTgGOCTs/T5VlX5\ngoIkSZpoXabgOHOhX1ZV5yRZsdDzSJIkLXVdVhwAIMnmSZ6Z5Pntz82HXNNTk1yS5IwkT5iljoOT\nrEqyavXq1UMuQZIkaXF1ud1JkrcChwKb0jyHBnBXkndW1duHUM9FwCOr6s4k+9G8oLDTdB2r6ljg\nWICVK1eulysh+BaoJEmaybxH0pK8BjgK+BKwH7ALzXNqXwKOSvKqhRZTVT+tqjvb7dOBDZNsvdDz\nSpIkrW+6jKQdAny4qg4ZOHYJcGaS24HXAh9ZSDFJtgFurKpKsitNiLxlIeeUJElaH3UJab8KvG6G\ntlOBV8x1giSfBfYAtk5yLfA2YEOAqvoocCDwqiT3AncDB1XVenkrU5IkaSG6hLRbgccCZ03T9ti2\nfVZV9cI52o+hmaJDkiRponUJaacAb09yI/D5tSNcSX4f+CvgsyOoT3R7wcCXESRJWhq6hLRDgScD\nJwNrktwELAc2Br7dtkuSJGkIukxme3uS3wJ+H3gasCXNLc5/Bk6tqvtGU6JGwRE3SZL6rdM8aW0Q\n+3z70QQwzEmStDhmDWlJlgN/A3y6qs6Yoc++wIuB11bVnC8PaGkyzEmSNFxzjaS9HtgNeOksfc4C\nPkgzT9qRQ6pLS5iBTpKkuc214sD+wEer6t6ZOrRtHwMOGGZhkiRJk2yukLYTzXqac/kO8JiFlyNJ\nkiSY39qdv5hHn2LdguuSJElaoLlC2g9pFlKfyy7ANQuuRpIkScDcIe2rwBuSbDFThyQPpXnB4MvD\nLEySJGmSzRXS3gNsBJybZN8ky9Y2JFnWTr9xLs0i6e8dXZmSJEmTZdYpOKpqdZK9gS8BX6FZDur6\ntnlbmiWhfgDsXVWrR1qpJEnSBJlzxYGqujTJrwMvAJ4F7NA2nQv8I3ByVd0zuhIlSZImz7yWhWpD\n2KfajyRJkkZsPlNwSJIkacwMaZIkST1kSJMkSeohQ5okSVIPGdIkSZJ6yJAmSZLUQ7NOwZHk9A7n\nqqp6zgLrkSRJEnPPk7YlUOMoRJIkSevMtSzU7uMqRJIkSevMa8UBaTEccPhJ9zt26jsOWoRKJEka\nv84hLclmwK8Bm0xtq6oLhlGU1IVhTpK0FM07pCXZCPgo8GJg2QzdZjouSZKkDrqMpB0OPAd4FfB3\nwBuBNcBLaV4w+PO5TpDk48D+wE1V9cRp2gN8ENgPuAt4WVVd1KFGaUaOuEmS1idd5kl7AXAUcEK7\nf05VfaR9ueAK4OnzOMcJwD6ztO8L7NR+DgY+0qE+SZKkJaPLSNojgcuq6r4kPwceNNB2LHA88KbZ\nTlBV5yRZMUuXA4BPVlUB5yXZIsm2VXV9hzqlBXPUTZK02LqMpN0CPLjdvhZ40kDbFsBmQ6hnO+BH\nA/vXtsfuJ8nBSVYlWbV69eohfLUkSVJ/dBlJ+zZNMDsdOAU4KsnGwL3AocC/DL+8mVXVsTQjeKxc\nudIJd7Uo5jviNux+kqSlr0tIOxpY0W7/FfA44L1AgIuB1wyhnuuAHQb2t2+PSZrC4CdJS9u8Q1pV\nnQec127/BHhOks2BTavqpiHVcxpwSJKTgN2A230eTZIkTaJ5P5OW5C1Jthk8VlV3VNVNSR6e5C3z\nOMdngX8FHpvk2iQvT/LKJK9su5wOXA1cRTPNx6vn/ZtIkiQtIV1ud74T+Cfghmnatm/bj57tBFX1\nwjnai+HcNpUkSVqvdQlpmaXtV4B7FliLpEXkM26S1C+zhrQkv8MvT1L7siTPmtJtU5r5za4ccm2S\nJEkTa66RtGcCb2u3C3jlNH0K+B5wyBDrkrQEOOomSQ/cXC8O/DXNSNmDaG53Pr3dH/xsUFWPr6pz\nRlmoJEnSJJl1JK2q7gPuA0iyaVWtGUtVkiaKI26SdH9d5klb064w8BLgGcCWwK3A2cBnDHCSJEnD\nM++QlmQ58E3gCcCNNFNxPBn4I+ANSfasqptHUqUk4RuokiZLlwXW3w1sC+xVVdtW1S5VtS2wF7BN\n2y5JkqQh6DJP2v7AYVX1jcGDVfWNJG+lWc9TktYrjrpJ6qsuIe0hwH/M0HZN2y5JS5JhTtK4dbnd\n+e/ATMs6vaBtlyRJ0hB0GUn7AHB8+wLBZ4DraZ5FO4jmVujLh1+eJK1fHHGTNCxdpuD4RJLNgSOA\nfWlWGgjNNBxvqKoTRlKhJC1BhjlJc+kykkZVfSjJR4Ansm6etO9W1c9HUZwkyalHpEk11wLrVwO/\nX1WXrD3WBrLvjLowSZKkSTbXSNoKYOMx1CFJGhNH5qT1Q6fbnZIkTTVdmAODn7RQ85mCo0ZehSRJ\nkn7JfEbSjkwynzU5q6peutCCJElyxE2aX0jbGVgzj36OuEmSJA3JfELa71XVBSOvRJIkSf+py7JQ\nkiRJGhPf7pQkrbcWMp3ITH2lvjCkSZI0YNjzyPkShB6oWUNaVXk7VJKkMXC+OU1lCJMkSeqhsd/u\nTLIP8EFgGXBcVb1rSvvLgPcA17WHjqmq48ZapCRJS4C3ZNdvYw1pSZYBfwvsBVwLfDvJaVV1xZSu\nJ1fVIeOsTZIkqU/GfbtzV+Cqqrq6qu4BTgIOGHMNkiRJvTfu253bAT8a2L8W2G2afn+Q5OnAvwN/\nVlU/mtohycHAwQA77rjjCEqVJEmDnMpkvPo4BceXgc9W1Zok/wM4EdhzaqeqOhY4FmDlypUuSSVJ\nUo/4nNvCjft253XADgP727PuBQEAquqWqlq7VuhxwFPGVJskSVJvjDukfRvYKcmjkmwEHAScNtgh\nybYDu88FrhxjfZIkSb0w1tudVXVvkkOAM2mm4Ph4VV2e5ChgVVWdBrwuyXOBe4FbgZeNs0ZJkqQ+\nGPszaVV1OnD6lGNHDGwfBhw27rokSZL6xBUHJEmSesiQJkmS1EOGNEmSpB4ypEmSJPWQIU2SJKmH\nDGmSJEk9ZEiTJEnqIUOaJElSDxnSJEmSemjsKw5IkiStdcDhJ93v2KnvOGgRKukfR9IkSZJ6yJE0\nSZLUe5M44uZImiRJUg85kiZJkpaM6UbcYP0cdXMkTZIkqYccSZMkSROp78+5OZImSZLUQ4Y0SZKk\nHjKkSZIk9ZAhTZIkqYcMaZIkST1kSJMkSeohQ5okSVIPGdIkSZJ6yJAmSZLUQ4Y0SZKkHhp7SEuy\nT5LvJbkqyaHTtG+c5OS2/fwkK8ZdoyRJ0mIba0hLsgz4W2Bf4PHAC5M8fkq3lwO3VdWjgQ8A7x5n\njZIkSX0w7pG0XYGrqurqqroHOAk4YEqfA4AT2+3PA89MkjHWKEmStOjGHdK2A340sH9te2zaPlV1\nL3A7sNVYqpMkSeqJVNX4viw5ENinql7R7r8E2K2qDhno8922z7Xt/vfbPjdPOdfBwMHt7mOB743h\nV1hra+DmOXtpMXht+snr0l9em37yuvTXMK7NI6tq+VydNljgl3R1HbDDwP727bHp+lybZAPgV4Bb\npp6oqo4Fjh1RnbNKsqqqVi7Gd2t2Xpt+8rr0l9emn7wu/TXOazPu253fBnZK8qgkGwEHAadN6XMa\n8NJ2+0DgmzXO4T5JkqQeGOtIWlXdm+QQ4ExgGfDxqro8yVHAqqo6DTge+FSSq4BbaYKcJEnSRBn3\n7U6q6nTg9CnHjhjY/hnw/HHX1dGi3GbVvHht+snr0l9em37yuvTX2K7NWF8ckCRJ0vy4LJQkSVIP\nGdI6mmtZK41Hko8nuamdsmXtsS2TnJXk/7Y/H7qYNU6qJDskOTvJFUkuT/L69rjXZxEl2STJBUku\naa/Lke3xR7VL8F3VLsm30WLXOomSLEvynSRfafe9Lj2Q5IdJLktycZJV7bGx/S0zpHUwz2WtNB4n\nAPtMOXYo8I2q2gn4Rruv8bsXeFNVPR7YHXhN+78Tr8/iWgPsWVW/AewM7JNkd5ql9z7QLsV3G83S\nfBq/1wNXDux7Xfrjv1XVzgPTboztb5khrZv5LGulMaiqc2je/h00uKTYicDvjbUoAVBV11fVRe32\nHTT/4dkOr8+iqsad7e6G7aeAPWmW4AOvy6JIsj3wHOC4dj94XfpsbH/LDGndzGdZKy2eh1fV9e32\nDcDDF7MYQZIVwC7A+Xh9Fl17S+1i4CbgLOD7wE/aJfjAv2mL5W+AtwC/aPe3wuvSFwV8PcmF7UpH\nMMa/ZWOfgkMah6qqJL66vIiSPBj4AvCGqvppMzjQ8Posjqq6D9g5yRbAl4DHLXJJEy/J/sBNVXVh\nkj0Wux7dz+9U1XVJHgacleTfBhtH/bfMkbRu5rOslRbPjUm2BWh/3rTI9UysJBvSBLTPVNUX28Ne\nn56oqp8AZwNPBbZol+AD/6Ytht8GnpvkhzSP0OwJfBCvSy9U1XXtz5to/o/Nrozxb5khrZv5LGul\nxTO4pNhLgVMXsZaJ1T5PczxwZVW9f6DJ67OIkixvR9BIsimwF83zgmfTLMEHXpexq6rDqmr7qlpB\n89+Ub1bVH+F1WXRJNkuy+dpt4NnAdxnj3zIns+0oyX40zw+sXdbq7Ytc0kRK8llgD2Br4EbgbcAp\nwOeAHYFrgD+sqqkvF2jEkvwO8C3gMtY9Y3M4zXNpXp9FkuRJNA85L6P5P+ifq6qjkvwqzQjOlsB3\ngBdX1ZrFq3Rytbc731xV+3tdFl97Db7U7m4A/H1VvT3JVozpb5khTZIkqYe83SlJktRDhjRJkqQe\nMqRJkiT1kCFNkiSphwxpkiRJPWRIk7QkJKl5fH44ou8+aepM5JK0UC4LJWmpeOqU/S8BlwB/OXBs\nVPNMvRXYbETnljShDGmSloSqOm9wP8ka4Oapx0f03VeN+jskTR5vd0qaSEn+JMllSdYkWZ3kE+0i\nyoN9bkhyXJJXJ7k6yc+SfDvJ06b0u9/tziSbJ3lv++/WJLk+yT+0s5VL0pwMaZImTpLXAR8HLgZ+\nj+Z25XOBs9t1LQftDbwK+AvgRe2xM5M8apbzb0Kz9uIrgeOA5wCvA+4AHjK830TSUubtTkkTJclG\nNGu9nllVLxk4/n3gLOAlwLED/2Rr4Der6oa239k06/UdDvzpDF/z34GnAHtX1dcHjv/DsH4PSUuf\nI2mSJs0TaRat/vTgwar6R+BG4BlT+n9rbUBr+90GnMn9X1QY9GzgmikBTZI6MaRJmjRbtj+vn6bt\nhoH2tW6cpt+NwHazfMdWwLXdS5OkdQxpkibNre3PbaZp22agfa2HT9Pv4cB1s3zHzcwe4iRpToY0\nSZPmuzRB7KDBg0meSRO+/mlK/6cl2Wag30NpXib411m+4+vAiiR7DaNgSZPJkCZpolTVPcCRwP7t\ntBv7JDkYOAm4ginPqtGMip2V5PlJnkcTwDYA3j7L13wCuBD4QpJDkzwzyfOS/N1sb4VK0iDf7pQ0\ncarqQ0nuBP6MZlqNnwJfBd5SVXdP6X4mcBFwNPAI4DKatzZ/OMv5f5ZkT5ow+Gqa26g3A98Cbh/u\nbyNpqUpVLXYNktRLSW4AvlJVr1jsWiRNHm93SpIk9ZAhTZIkqYe83SlJktRDjqRJkiT1kCFNkiSp\nhwxpkiTvbKgKAAAAHElEQVRJPWRIkyRJ6iFDmiRJUg8Z0iRJknro/wMQsA7cKU2zlQAAAABJRU5E\nrkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11112b7f0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(10,5))\n",
+    "plt.bar(range(topic_model.tcs.shape[0]), topic_model.tcs, color = '#4e79a7', width = 0.5)\n",
+    "plt.xlabel('Topic', fontsize = 16)\n",
+    "plt.ylabel('Total Correlation (nats)', fontsize = 16)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see the first topic of image encodings is the most informative. We could consider doing additional preprocessing to remove the encodings so that our CorEx topic model does not pick up on their patterns."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pointwise Document TC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can decompose total correlation further. The topic correlation is the average of the pointwise total correlations for each individual document. The pointwise total correlations can be accessed through `log_z`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(11314, 50)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "topic_model.log_z.shape # n_docs x k_topics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 3.64813418  1.57958569  1.48835238  1.42639341  1.42043661  1.39232446\n",
+      "  1.37222362  1.36535367  1.34334261  1.08793513  1.06264005  1.03767991\n",
+      "  1.01780633  0.98444346  0.98350034  0.97751588  0.97425573  0.96560217\n",
+      "  0.9170467   0.91160502  0.87920818  0.86341492  0.83259909  0.82311403\n",
+      "  0.79730235  0.78507652  0.76449939  0.74186846  0.73348486  0.7232203\n",
+      "  0.70714498  0.70407292  0.6876558   0.68271949  0.66403509  0.60590956\n",
+      "  0.59919508  0.58802044  0.5869777   0.58426131  0.57613847  0.57032326\n",
+      "  0.5434933   0.54324576  0.504955    0.48664151  0.28893956  0.27183877\n",
+      "  0.24173114  0.21054385]\n",
+      "[ 3.64813418  1.57958569  1.48835238  1.42639341  1.42043661  1.39232446\n",
+      "  1.37222362  1.36535367  1.34334261  1.08793513  1.06264005  1.03767991\n",
+      "  1.01780633  0.98444346  0.98350034  0.97751588  0.97425573  0.96560217\n",
+      "  0.9170467   0.91160502  0.87920818  0.86341492  0.83259909  0.82311403\n",
+      "  0.79730235  0.78507652  0.76449939  0.74186846  0.73348486  0.7232203\n",
+      "  0.70714498  0.70407292  0.6876558   0.68271949  0.66403509  0.60590956\n",
+      "  0.59919508  0.58802044  0.5869777   0.58426131  0.57613847  0.57032326\n",
+      "  0.5434933   0.54324576  0.504955    0.48664151  0.28893956  0.27183877\n",
+      "  0.24173114  0.21054385]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.mean(topic_model.log_z, axis = 0))\n",
+    "print(topic_model.tcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The pointwise total correlations in `log_z` represent the correlations within an individual document explained by a particular topic. These correlations have been used to measure how \"surprising\" documents are with respect to given topics."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hierarchical Topic Models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `labels` attribute gives the binary topic expressions for each document and each topic. We can use this output as input to another CorEx topic model to get latent representations of the topics themselves. This yields a hierarchical CorEx topic model. Like the first layer of the topic model, one can determine the number of latent variables to add in higher layers through examination of the topic TCs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Train a second layer to the topic model\n",
+    "tm_layer2 = ct.Corex(n_hidden=10)\n",
+    "tm_layer2.fit(topic_model.labels);\n",
+    "\n",
+    "# Train a third layer to the topic model\n",
+    "tm_layer3 = ct.Corex(n_hidden=1)\n",
+    "tm_layer3.fit(tm_layer2.labels);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you have graphviz installed, then you can output visualizations of the hierarchial topic model to your current working directory. One can also create custom visualizations of the hierarchy by properly making use of the `labels` attribute of each layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "vt.vis_hierarchy([topic_model, tm_layer2, tm_layer3], column_label=starred_words, max_edges=200, prefix='topic-model-example')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Anchoring for Semi-Supervised Topic Modeling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Anchored CorEx is an extension of CorEx that allows the \"anchoring\" of words to topics. When anchoring a word to a topic, CorEx is trying to maximize the mutual information between that word and the anchored topic. So, anchoring provides a way to guide the topic model towards specific subsets of words that the user would like to explore.  \n",
+    "\n",
+    "The anchoring mechanism is flexible, and so there are many possibilities of anchoring. We explored the following types of anchoring in our TACL paper:\n",
+    "\n",
+    "1. Anchoring a single set of words to a single topic. This can help promote a topic that did not naturally emerge when running an unsupervised instance of the CorEx topic model. For example, one might anchor words like \"snow,\" \"cold,\" and \"avalanche\" to a topic if one suspects there should be a snow avalanche topic within a set of disaster relief articles.\n",
+    "\n",
+    "2. Anchoring single sets of words to multiple topics. This can help find different aspects of a topic that may be discussed in several different contexts. For example, one might anchor \"protest\" to three topics and \"riot\" to three other topics to understand different framings that arise from tweets about political protests.\n",
+    "\n",
+    "3. Anchoring different sets of words to multiple topics. This can help enforce topic separability if there appear to be chimera topics. For example, one might anchor \"mountain,\" \"Bernese,\" and \"dog\" to one topic and \"mountain,\" \"rocky,\" and \"colorado\" to another topic to help separate topics that merge discussion of Bernese Mountain Dogs and the Rocky Mountains.\n",
+    "\n",
+    "\n",
+    "We'll demonstrate how easy it is to anchor the CorEx topic model and develop other anchoring strategies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Anchor one word to the first topic\n",
+    "anchor_words = ['nasa']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Anchor the word 'nasa' to the first topic\n",
+    "anchored_topic_model = ct.Corex(n_hidden=50, seed=2)\n",
+    "anchored_topic_model.fit(doc_word, words=words, anchors=anchor_words, anchor_strength=6);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This anchors the single word \"nasa\" to the first topic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: nasa,gov,ames,institute,jpl,station,propulsion,jsc,arc,shafer\n"
+     ]
+    }
+   ],
+   "source": [
+    "topic_words,_ = zip(*anchored_topic_model.get_topics(topic=0))\n",
+    "print('0: ' + ','.join(topic_words))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can anchor multiple groups of words to multiple topics as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Anchor 'nasa' and 'space' to first topic, 'sports' and 'stadium' to second topic, so on...\n",
+    "anchor_words = [['nasa', 'space'], ['sports', 'stadium'], ['politics', 'government'], ['love', 'hope']]\n",
+    "\n",
+    "anchored_topic_model = ct.Corex(n_hidden=50, seed=2)\n",
+    "anchored_topic_model.fit(doc_word, words=words, anchors=anchor_words, anchor_strength=6);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: space,nasa,orbit,moon,shuttle,launch,gov,earth,lunar,ames\n",
+      "1: sports,stadium,april,san,city,los,york,washington,angeles,center\n",
+      "2: government,politics,state,rights,law,war,country,military,public,security\n",
+      "3: hope,love,helps,relates,virile,tatoos,sustaining,whosoever,weird,allegory\n"
+     ]
+    }
+   ],
+   "source": [
+    "for n in range(len(anchor_words)):\n",
+    "    topic_words,_ = zip(*anchored_topic_model.get_topics(topic=n))\n",
+    "    print('{}: '.format(n) + ','.join(topic_words))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note, in the above topic model, topics will no longer be sorted according to descending TC. Instead, the first topic will be the one with \"nasa\" and \"space\" anchored to it, the second topic will be the one with \"sports\" and \"stadium\" anchored to it, and so on.  \n",
+    "\n",
+    "Observe, the topic with \"love\" and \"hope\" anchored to it is less interpretable than the other three topics. This could be a sign that there is not a good topic around these two words, and one should consider if it is appropriate to anchor around them.\n",
+    "\n",
+    "We can continue to develop even more involved anchoring strategies. Here we anchor \"nasa\" by itself, as well as in two other topics each with \"politics\" and \"news\" to find different aspects around the word \"nasa\". We also create a fourth anchoring of \"war\" to a topic."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Anchor with single words and groups of words\n",
+    "anchor_words = ['nasa', ['nasa', 'politics'], ['nasa', 'news'], 'war']\n",
+    "\n",
+    "anchored_topic_model = ct.Corex(n_hidden=50, seed=2)\n",
+    "anchored_topic_model.fit(doc_word, words=words, anchors=anchor_words, anchor_strength=6);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0: nasa,space,orbit,launch,shuttle,moon,earth,lunar,satellite,commercial\n",
+      "1: nasa,politics,research,gov,science,scientific,institute,organization,studies,providing\n",
+      "2: news,nasa,insisting,edwards,hal,llnl,cso,cfv,nodak,admin\n",
+      "3: war,israel,armenians,armenian,israeli,jews,soldiers,military,killed,history\n"
+     ]
+    }
+   ],
+   "source": [
+    "for n in range(len(anchor_words)):\n",
+    "    topic_words,_ = zip(*anchored_topic_model.get_topics(topic=n))\n",
+    "    print('{}: '.format(n) + ','.join(topic_words))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note:** If you do not specify the column labels through `words`, then you can still anchor by specifying the column indices of the features you wish to anchor on. You may also specify anchors using a mix of strings and indices if desired."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Choosing anchor strength:** the anchor strength controls how much weight CorEx puts towards maximizing the mutual information between the anchor words and their respective topics. Anchor strength should always be set at a value *greater than* 1, since setting anchor strength between 0 and 1 only recovers the unsupervised CorEx objective. Empirically, setting anchor strength from 1.5-3 seems to nudge the topic model towards the anchor words. Setting anchor strength greater than 5 is strongly enforcing that the CorEx topic model find a topic associated with the anchor words.\n",
+    "\n",
+    "We encourage users to experiment with the anchor strength and determine what values are best for their needs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Other Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `vis_topic` module provides support for outputting topics and visualizations of the CorEx topic model. The code below creates a results direcory named \"twenty\" in your working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "vt.vis_rep(topic_model, column_label=words, prefix='twenty')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Further Reading"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our TACL paper details the theory of the CorEx topic model, its sparsity optimization, anchoring via the information bottleneck, comparisons to LDA, and anchoring experiments. The two papers from Greg Ver Steeg and Aram Galstyan develop the CorEx theory in general and provide further motivation and details of the underlying CorEx mechanisms. Hodas et al. demonstrated early CorEx topic model results and investigated an application of pointwise total correlations to quantify \"surprising\" documents.\n",
+    "\n",
+    "1. [Anchored Correlation Explanation: Topic Modeling with Minimal Domain Knowledge](hhttps://www.transacl.org/ojs/index.php/tacl/article/view/1244), Gallagher et al., TACL 2017.\n",
+    "\n",
+    "2. [Discovering Structure in High-Dimensional Data Through Correlation Explanation](https://arxiv.org/abs/1406.1222), Ver Steeg and Galstyan, NIPS 2014. \n",
+    "\n",
+    "3. [Maximally Informative Hierarchical Representions of High-Dimensional Data](https://arxiv.org/abs/1410.7404), Ver Steeg and Galstyan, AISTATS 2015.\n",
+    "\n",
+    "4. [Disentangling the Lexicons of Disaster Response in Twitter](https://dl.acm.org/citation.cfm?id=2741728), Hodas et al., WWW 2015."
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
1. Made the Python example notebook Python 3 compatible and made the examples a little more interesting. Also made sure to set seeds so it should be directly reproducible
2. Added functionality so you can add labels to the doc-term matrix columns (terms) more easily after having trained a CorEx model.
3. Added a new attribute to set labels for the rows (docs), including the ability to set the doc labels after training the CorEx topic model.
4. Added a "get_top_docs" function which returns documents sorted according to probability or TC. I put a warning under TC because we're still trying to figure out the right way to think about it.

If someone could check to make sure I'm sorting documents correctly, that'd be great. I think everything else should be in order.