### PR TITLE
Add `y` argument to fit method, for sklearn compatibility

### DIFF
--- a/corextopic/corextopic.py
+++ b/corextopic/corextopic.py
@@ -143,14 +143,14 @@ class Corex(object):
         """
         return np.sum(self.tcs)
 
-    def fit(self, X, anchors=None, anchor_strength=1, words=None, docs=None):
+    def fit(self, X, y=None, anchors=None, anchor_strength=1, words=None, docs=None):
         """
         Fit CorEx on the data X. See fit_transform.
         """
         self.fit_transform(X, anchors=anchors, anchor_strength=anchor_strength, words=words, docs=docs)
         return self
 
-    def fit_transform(self, X, anchors=None, anchor_strength=1, words=None, docs=None):
+    def fit_transform(self, X, y=None, anchors=None, anchor_strength=1, words=None, docs=None):
         """Fit CorEx on the data
 
         Parameters


### PR DESCRIPTION
The fit() method in sklearn has the signature `fit(X,y)` even if the class doesn't use the `y` value.  This allows the object to be used in Pipelines, etc.

For example, note the fit() method for `CountVectorizer`:  https://github.com/scikit-learn/scikit-learn/blob/bac89c2/sklearn/feature_extraction/text.py#L966