### PR TITLE
corextopic / sklearn compatibility issue due to joblib

### DIFF
--- a/corextopic/corextopic.py
+++ b/corextopic/corextopic.py
@@ -28,7 +28,7 @@ except ImportError:
     from scipy.misc import logsumexp  # Tested with 0.13.0
 import scipy.sparse as ss
 from six import string_types # For Python 2&3 compatible string checking
-from sklearn.externals import joblib
+import joblib
 
 
 class Corex(object):


### PR DESCRIPTION
Switching to `joblib` from `sklearn.externals.joblib` since `sklearn.externals.joblib` is deprecated in 0.21 and subsequently removed in 0.23.

The recommendation from `sklearn` is to switch to `joblib`, as per their deprecation warning.

Tested on my pipelines using python 3.6 & 3.7 on Amazon Linux.